### PR TITLE
feat: Add Haruna Media Player

### DIFF
--- a/usr/etc/flatpak/user/install
+++ b/usr/etc/flatpak/user/install
@@ -14,4 +14,4 @@ org.kde.kclock
 com.github.tchx84.Flatseal
 org.fedoraproject.MediaWriter
 io.missioncenter.MissionCenter
-io.github.celluloid_player.Celluloid
+org.kde.haruna


### PR DESCRIPTION
Replaces Celluloid with [Haruna](https://haruna.kde.org/) since it uses Qt and is an official KDE application.

If you prefer Celluloid then that is fine!