### PR TITLE
feat: Add KDE's Filelight

### DIFF
--- a/usr/etc/flatpak/system/install
+++ b/usr/etc/flatpak/system/install
@@ -11,9 +11,10 @@ org.gnome.Logs
 org.gnome.Maps
 org.kde.kweather
 org.kde.kclock
+org.kde.haruna
+org.kde.filelight
 com.github.tchx84.Flatseal
 io.github.dvlv.boxbuddyrs
 io.github.flattool.Warehouse
 org.fedoraproject.MediaWriter
 io.missioncenter.MissionCenter
-org.kde.haruna


### PR DESCRIPTION
https://apps.kde.org/filelight/

It's the alternative to GNOME's Disk Usage Analyzer.

Also re-organized files by name

<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
