### PR TITLE
chore: Remove KDE's welcome application

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -108,9 +108,11 @@
 		"exclude": {
 			"aurora": [
 				"ublue-os-update-services"
+				"plasma-welcome"
 			],
 			"aurora-dx": [
 				"ublue-os-update-services"
+				"plasma-welcome"
 			]
 		}
 	},


### PR DESCRIPTION
Opinionated change.  Bazzite does this because it can confuse users on first-boot when YAFTI launches in front of it.

<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
