### PR TITLE
fix: Load nvidia drivers in the initramfs for faster startup times

### DIFF
--- a/etc/dracut.conf.d/nvidia.conf
+++ b/etc/dracut.conf.d/nvidia.conf
@@ -1,0 +1,1 @@
+force_drivers+=" nvidia nvidia_modeset nvidia_uvm nvidia_drm "


### PR DESCRIPTION
<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
fix: Load nvidia drivers in the initramfs for faster startup times