### PR TITLE
chore: Remove GNOME Flatpaks

### DIFF
--- a/flatpaks/flatpaks
+++ b/flatpaks/flatpaks
@@ -1,13 +1,8 @@
 app/org.mozilla.Thunderbird/x86_64/stable
 app/org.kde.kcalc/x86_64/stable
 app/org.kde.gwenview/x86_64/stable
-app/org.gnome.Calendar/x86_64/stable
-app/org.gnome.Characters/x86_64/stable
-app/org.gnome.Connections/x86_64/stable
 app/org.kde.kontact/x86_64/stable
 app/org.kde.okular/x86_64/stable
-app/org.gnome.Logs/x86_64/stable
-app/org.gnome.Maps/x86_64/stable
 app/org.kde.kweather/x86_64/stable
 app/org.kde.kclock/x86_64/stable
 app/org.kde.haruna/x86_64/stable


### PR DESCRIPTION
We'll have to figure this out another day to replace them with equivalents that are **verified Qt applications**, or we don't have to.  KDE has a Flatpak repo that contains a lot of equivalents, but that would be messy to include another repo.  Replacing them with an alternative will be a future endeavor.

What has been removed:

- GNOME Calendar
- GNOME Characters
- GNOME Connections
- GNOME Logs
- GNOME Maps

I left in Mission Center.  It is up to you if you want to keep that or not in the future.

<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
